### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @eslint-community/eslint-plugin-eslint-plugin


### PR DESCRIPTION
> [Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners)

Currently this file marks the maintainers as owners of the project.
This is both redundant and annoying because (as per above) it means that the maintainers are forcibly added as a reviewer to every PR; meaning that maintainers are forcibly spammed with notifications.
Adding as a reviewer forces maintainers to be "participating" in every PR - which overrides any other notification settings one might set on the repo.
If we had owners for individual parts of the project - then CODEOWNERS would be desirable, but as it stands it's just a negative, IMO.