### PR TITLE
chore(CI): add automatic release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: CI
 on:
   push:
+    branches:
+      # default semantic-release branches
+      - +([0-9])?(.{+([0-9]),x}).x
+      - main
+      - next
+      - next-major
+      - beta
+      - alpha
   pull_request:
 
 jobs:
@@ -73,3 +81,42 @@ jobs:
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3
 
+  release:
+    name: 🚀 Release
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    if:
+      github.repository == 'eslint-community/eslint-plugin-eslint-plugin' &&
+      contains('refs/heads/main,refs/heads/next,refs/heads/beta,refs/heads/alpha',
+      github.ref) && github.event_name == 'push'
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: 📥 Install dependencies
+        run: npm install
+
+      - name: 🚀 Release
+        uses: cycjimmy/semantic-release-action@v3
+        with:
+          semantic_version: 19
+          branches: |
+            [
+              '+([0-9])?(.{+([0-9]),x}).x',
+              'main',
+              'next',
+              'next-major',
+              {name: 'beta', prerelease: true},
+              {name: 'alpha', prerelease: true}
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,48 +1,75 @@
 name: CI
-
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
 
 jobs:
-  test:
-    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - '18'
-          - '16'
-          - '14'
-        os:
-          - ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm test
-
   lint:
+    name: ⬣ Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-      - run: npm install
-      - run: npm run lint
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
 
-  eslint7:
-    runs-on: ubuntu-latest
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: 📥 Install dependencies
+        run: npm install
+
+      - name: ▶️ Run lint script
+        run: npm run lint
+
+  test:
+    name: 🧪 Test (Node@${{ matrix.node }} - ESLint@${{ matrix.eslint }} - ${{ matrix.os }})
+    strategy:
+      matrix:
+        eslint: [8]
+        node: [14.17.0, 14, 16.0.0, 16, 18.0.0, 18]
+        os: [ubuntu-latest]
+        include:
+          # On other platforms
+          - os: windows-latest
+            eslint: 8
+            node: 18
+          - os: macos-latest
+            eslint: 8
+            node: 18
+          # On old ESLint versions
+          - eslint: 7
+            node: 18
+            os: ubuntu-latest
+          # On the minimum supported ESLint/Node.js version
+          - eslint: 7.0.0
+            node: 14.17.0
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: "18.x"
-    - run: npm install
-    - run: npm install --save-dev eslint@7
-    - run: npm test
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: 📥 Install dependencies
+        run: npm install
+
+      - name: 📥 Install ESLint
+        run: npm install --no-install eslint@${{ matrix.eslint }}
+
+      - name: ▶️ Run test script
+        run: npm run test
+
+      - name: ⬆️ Upload coverage report
+        uses: codecov/codecov-action@v3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-eslint-plugin",
-  "version": "5.0.6",
+  "version": "0.0.0-semantically-released",
   "description": "An ESLint plugin for linting ESLint plugins",
   "author": "Teddy Katz",
   "main": "./lib/index.js",
@@ -15,7 +15,6 @@
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs --check\"",
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
-    "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive",
     "update:eslint-docs": "eslint-doc-generator --rule-doc-section-include \"Rule Detail\" --ignore-config all --ignore-config rules --ignore-config rules-recommended --ignore-config tests --ignore-config tests-recommended"
   },
@@ -48,7 +47,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@release-it/conventional-changelog": "^4.3.0",
     "@typescript-eslint/parser": "^5.36.2",
     "chai": "^4.3.6",
     "dirty-chai": "^2.0.1",
@@ -72,7 +70,6 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
-    "release-it": "^14.14.3",
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
@@ -80,22 +77,5 @@
   },
   "engines": {
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
-  },
-  "release-it": {
-    "git": {
-      "commitMessage": "chore: release v${version}"
-    },
-    "plugins": {
-      "@release-it/conventional-changelog": {
-        "preset": "conventionalcommits",
-        "infile": "CHANGELOG.md"
-      }
-    },
-    "github": {
-      "release": true
-    },
-    "npm": {
-      "skipChecks": true
-    }
   }
 }


### PR DESCRIPTION
@eslint-community/eslint-tsc In order to make the automatic release work, we should add the `NPM_TOKEN` secret in [the Action secret settings](https://github.com/organizations/eslint-community/settings/secrets/actions).

I think it's best to set a PAT for [the `eslint-community-bot` npm user](https://www.npmjs.com/~eslint-community-bot) btw.

---

This branch depends on #313

Closes #301

---

This PR is inspired by what I did for `@mysticatea/eslint-plugin` in https://github.com/eslint-community/mysticatea__eslint-plugin/pull/8