### PR TITLE
Fix Node 14.17 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     'unicorn/no-array-reduce': 'off',
     'unicorn/no-null': 'off',
     'unicorn/prefer-module': 'off',
+    'unicorn/prefer-node-protocol': 'off', // TODO: enable once we drop support for Node 14.17.
     'unicorn/prevent-abbreviations': 'off',
   },
   overrides: [

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,8 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require('fs');
+const path = require('path');
 const packageMetadata = require('../package');
 const PLUGIN_NAME = packageMetadata.name.replace(/^eslint-plugin-/, '');
 

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const path = require('node:path');
+const path = require('path');
 const util = require('../utils');
 const { getStaticValue } = require('eslint-utils');
 

--- a/tests/lib/rule-setup.js
+++ b/tests/lib/rule-setup.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { readdirSync, readFileSync } = require('node:fs');
-const path = require('node:path');
+const { readdirSync, readFileSync } = require('fs');
+const path = require('path');
 const assert = require('chai').assert;
 const plugin = require('../..');
 

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { inspect } = require('node:util');
+const { inspect } = require('util');
 const lodash = require('lodash');
 const espree = require('espree');
 const eslintScope = require('eslint-scope');


### PR DESCRIPTION
We can't use Node protocol imports until we drop support for Node 14.17 (https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md).

This issue was caught in: #313

This bug was added in: https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/302

