### PR TITLE
docs: update eslint-doc-generator to 0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here's an example ESLint configuration that:
 
 ## <a name='Rules'></a>Rules
 
-<!-- begin rules list -->
+<!-- begin auto-generated rules list -->
 
 ✅ Enabled in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
@@ -89,7 +89,7 @@ Here's an example ESLint configuration that:
 | [test-case-property-ordering](docs/rules/test-case-property-ordering.md)                                                                                   | require the properties of a test case to be placed in a consistent order                   |     | 🔧  |     |
 | [test-case-shorthand-strings](docs/rules/test-case-shorthand-strings.md)                                                                                   | enforce consistent usage of shorthand strings for test cases with no options               |     | 🔧  |     |
 
-<!-- end rules list -->
+<!-- end auto-generated rules list -->
 
 ## <a name='Presets'></a>Presets
 

--- a/docs/rules/consistent-output.md
+++ b/docs/rules/consistent-output.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 When writing tests for fixable rules, the `output` property on each test case can be used to assert what autofixed code is produced, or to assert that no autofix is produced using `output: null`.
 

--- a/docs/rules/fixer-return.md
+++ b/docs/rules/fixer-return.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 In a [fixable](https://eslint.org/docs/developer-guide/working-with-rules#applying-fixes) rule, a fixer function is useless if it never returns anything.
 

--- a/docs/rules/meta-property-ordering.md
+++ b/docs/rules/meta-property-ordering.md
@@ -2,7 +2,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule enforces that meta properties of a rule are placed in a consistent order.
 

--- a/docs/rules/no-deprecated-context-methods.md
+++ b/docs/rules/no-deprecated-context-methods.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule disallows the use of deprecated methods on rule `context` objects.
 

--- a/docs/rules/no-deprecated-report-api.md
+++ b/docs/rules/no-deprecated-report-api.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 ESLint has two APIs that rules can use to report problems.
 

--- a/docs/rules/no-identical-tests.md
+++ b/docs/rules/no-identical-tests.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Duplicate test cases can cause confusion, can be hard to detect manually in a long file, and serve no purpose.
 

--- a/docs/rules/no-missing-message-ids.md
+++ b/docs/rules/no-missing-message-ids.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 When using `meta.messages` and `messageId` to report rule violations, it's possible to mistakenly use a `messageId` that doesn't exist in `meta.messages`.
 

--- a/docs/rules/no-missing-placeholders.md
+++ b/docs/rules/no-missing-placeholders.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Report messages in rules can have placeholders surrounded by curly brackets.
 

--- a/docs/rules/no-only-tests.md
+++ b/docs/rules/no-only-tests.md
@@ -4,7 +4,7 @@
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 The [`only` property](https://eslint.org/docs/developer-guide/unit-tests#running-individual-tests) can be used as of [ESLint 7.29](https://eslint.org/blog/2021/06/eslint-v7.29.0-released#highlights) for running individual rule test cases with less-noisy debugging. This feature should be only used in development, as it prevents all the tests from running. Mistakenly checking-in a test case with this property can cause CI tests to incorrectly pass.
 

--- a/docs/rules/no-unused-message-ids.md
+++ b/docs/rules/no-unused-message-ids.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 When using `meta.messages` and `messageId` to report rule violations, it's possible to mistakenly leave a message in `meta.messages` that is never used.
 

--- a/docs/rules/no-unused-placeholders.md
+++ b/docs/rules/no-unused-placeholders.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule aims to disallow unused placeholders in rule report messages.
 

--- a/docs/rules/no-useless-token-range.md
+++ b/docs/rules/no-useless-token-range.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 AST nodes always start and end with tokens. As a result, the start index of the first token in a node is the same as the start index of the node itself, and the end index of the last token in a node is the same as the end index of the node itself. Using code like `sourceCode.getFirstToken(node).range[0]` unnecessarily hurts the performance of your rule, and makes your code less readable.
 

--- a/docs/rules/prefer-message-ids.md
+++ b/docs/rules/prefer-message-ids.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 When reporting a rule violation, it's preferred to provide the violation message with the `messageId` property instead of the `message` property. Message IDs provide the following benefits:
 

--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Prior to ESLint v9, ESLint supported both [function-style](https://eslint.org/docs/developer-guide/working-with-rules-deprecated) and [object-style](https://eslint.org/docs/developer-guide/working-with-rules) rules. However, function-style rules have been deprecated since 2016, and do not support newer features like autofixing and suggestions.
 

--- a/docs/rules/prefer-output-null.md
+++ b/docs/rules/prefer-output-null.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Instead of repeating the test case `code`, using `output: null` is more concise and makes it easier to distinguish whether a test case provides an autofix.
 

--- a/docs/rules/prefer-placeholders.md
+++ b/docs/rules/prefer-placeholders.md
@@ -1,6 +1,6 @@
 # Require using placeholders for dynamic report messages (`eslint-plugin/prefer-placeholders`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Report messages in rules can have placeholders surrounded by curly brackets.
 

--- a/docs/rules/prefer-replace-text.md
+++ b/docs/rules/prefer-replace-text.md
@@ -1,6 +1,6 @@
 # Require using `replaceText()` instead of `replaceTextRange()` (`eslint-plugin/prefer-replace-text`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 ## Rule Details
 

--- a/docs/rules/report-message-format.md
+++ b/docs/rules/report-message-format.md
@@ -1,6 +1,6 @@
 # Enforce a consistent format for rule report messages (`eslint-plugin/report-message-format`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 It is sometimes desirable to maintain consistent formatting for all report messages. For example, you might want to mandate that all report messages begin with a capital letter and end with a period.
 

--- a/docs/rules/require-meta-docs-description.md
+++ b/docs/rules/require-meta-docs-description.md
@@ -1,6 +1,6 @@
 # Require rules to implement a `meta.docs.description` property with the correct format (`eslint-plugin/require-meta-docs-description`)
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Defining a clear and consistent description for each rule helps developers understand what they're used for.
 

--- a/docs/rules/require-meta-docs-url.md
+++ b/docs/rules/require-meta-docs-url.md
@@ -2,7 +2,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 A rule can store the URL to its documentation page in `meta.docs.url`. This enables integration tools / IDEs / editors to conveniently provide the link to developers so that they can better understand the rule.
 

--- a/docs/rules/require-meta-fixable.md
+++ b/docs/rules/require-meta-fixable.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 ESLint requires fixable rules to specify a valid `meta.fixable` property (with value `code` or `whitespace`).
 

--- a/docs/rules/require-meta-has-suggestions.md
+++ b/docs/rules/require-meta-has-suggestions.md
@@ -4,7 +4,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 A suggestable ESLint rule should specify the `meta.hasSuggestions` property with a value of `true`. This makes it easier for both humans and tooling to tell whether a rule provides suggestions. [As of ESLint 8](https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property), an exception will be thrown if a suggestable rule is missing this property.
 

--- a/docs/rules/require-meta-schema.md
+++ b/docs/rules/require-meta-schema.md
@@ -4,7 +4,7 @@
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 Defining a schema for each rule allows eslint to validate that configuration options are passed correctly. Even when there are no options for a rule, a schema can still be defined as an empty array to validate that no data is mistakenly passed to the rule.
 

--- a/docs/rules/require-meta-type.md
+++ b/docs/rules/require-meta-type.md
@@ -2,7 +2,7 @@
 
 ✅ This rule is enabled in the `recommended` config.
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 ESLint v5.9.0 introduces a new `--fix-type` option for the command line interface. This option allows users to filter the type of fixes applied when using `--fix`.
 

--- a/docs/rules/test-case-property-ordering.md
+++ b/docs/rules/test-case-property-ordering.md
@@ -2,7 +2,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 This rule enforces that the properties of RuleTester test cases are arranged in a consistent order.
 

--- a/docs/rules/test-case-shorthand-strings.md
+++ b/docs/rules/test-case-shorthand-strings.md
@@ -2,7 +2,7 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-<!-- end rule header -->
+<!-- end auto-generated rule header -->
 
 When writing valid test cases for rules with `RuleTester`, one can optionally include a string as a test case instead of an object, if the the test case does not use any options.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint \"**/*.md\"",
-    "lint:eslint-docs": "npm-run-all \"update:eslint-docs --check\"",
+    "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
     "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "release": "release-it",
@@ -55,7 +55,7 @@
     "eslint": "^8.23.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^0.14.0",
+    "eslint-doc-generator": "^0.15.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "file:./",
     "eslint-plugin-markdown": "^3.0.0",


### PR DESCRIPTION
- Fixed argument forwarding in the lint script in package.json
- The marker comments now make it clear that the content is auto-generated

https://github.com/bmish/eslint-doc-generator/releases/tag/v0.15.0