### PR TITLE
chore: use eslint --no-inline-config to eliminate linting warnings in the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "license": "MIT",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "eslint --no-inline-config \"**/*.md\" && markdownlint \"**/*.md\"",
+    "lint:docs": "markdownlint \"**/*.md\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
     "lint:js": "eslint --cache --ignore-pattern \"**/*.md\" .",
+    "lint:js-docs": "eslint --no-inline-config \"**/*.md\"",
     "lint:package-json": "npmPkgJsonLint .",
     "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint \"**/*.md\"",
+    "lint:docs": "eslint --no-inline-config \"**/*.md\" && markdownlint \"**/*.md\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
-    "lint:js": "eslint --cache .",
+    "lint:js": "eslint --cache --ignore-pattern \"**/*.md\" .",
     "lint:package-json": "npmPkgJsonLint .",
     "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive",


### PR DESCRIPTION
as inline configs was widely used in the source code, I just separate the `eslint --no-inline-config docs` to npm script `lint:docs`.

fixes #140