### PR TITLE
docs: update eslint-doc-generator to 0.28

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,0 +1,6 @@
+/** @type {import('eslint-doc-generator').GenerateOptions} */
+module.exports = {
+  ignoreConfig: ['all', 'rules', 'rules-recommended', 'tests', 'tests-recommended'],
+  ruleDocSectionInclude: ['Rule Details'],
+  urlConfigs: 'https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets',
+};

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Here's an example ESLint configuration that:
 
 <!-- begin auto-generated rules list -->
 
-💼 Configurations enabled in.\
-✅ Set in the `recommended` configuration.\
+💼 [Configurations](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets) enabled in.\
+✅ Set in the `recommended` [configuration](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/consistent-output.md
+++ b/docs/rules/consistent-output.md
@@ -1,6 +1,6 @@
 # Enforce consistent use of `output` assertions in rule tests (`eslint-plugin/consistent-output`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/fixer-return.md
+++ b/docs/rules/fixer-return.md
@@ -1,6 +1,6 @@
 # Require fixer functions to return a fix (`eslint-plugin/fixer-return`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-deprecated-context-methods.md
+++ b/docs/rules/no-deprecated-context-methods.md
@@ -1,6 +1,6 @@
 # Disallow usage of deprecated methods on rule context objects (`eslint-plugin/no-deprecated-context-methods`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-deprecated-report-api.md
+++ b/docs/rules/no-deprecated-report-api.md
@@ -1,6 +1,6 @@
 # Disallow the version of `context.report()` with multiple arguments (`eslint-plugin/no-deprecated-report-api`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-identical-tests.md
+++ b/docs/rules/no-identical-tests.md
@@ -1,6 +1,6 @@
 # Disallow identical tests (`eslint-plugin/no-identical-tests`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/no-missing-message-ids.md
+++ b/docs/rules/no-missing-message-ids.md
@@ -1,6 +1,6 @@
 # Disallow `messageId`s that are missing from `meta.messages` (`eslint-plugin/no-missing-message-ids`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-missing-placeholders.md
+++ b/docs/rules/no-missing-placeholders.md
@@ -1,6 +1,6 @@
 # Disallow missing placeholders in rule report messages (`eslint-plugin/no-missing-placeholders`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-only-tests.md
+++ b/docs/rules/no-only-tests.md
@@ -1,6 +1,6 @@
 # Disallow the test case property `only` (`eslint-plugin/no-only-tests`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/no-unused-message-ids.md
+++ b/docs/rules/no-unused-message-ids.md
@@ -1,6 +1,6 @@
 # Disallow unused `messageId`s in `meta.messages` (`eslint-plugin/no-unused-message-ids`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-unused-placeholders.md
+++ b/docs/rules/no-unused-placeholders.md
@@ -1,6 +1,6 @@
 # Disallow unused placeholders in rule report messages (`eslint-plugin/no-unused-placeholders`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/no-useless-token-range.md
+++ b/docs/rules/no-useless-token-range.md
@@ -1,6 +1,6 @@
 # Disallow unnecessary calls to `sourceCode.getFirstToken()` and `sourceCode.getLastToken()` (`eslint-plugin/no-useless-token-range`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/prefer-message-ids.md
+++ b/docs/rules/prefer-message-ids.md
@@ -1,6 +1,6 @@
 # Require using `messageId` instead of `message` to report rule violations (`eslint-plugin/prefer-message-ids`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -1,6 +1,6 @@
 # Disallow function-style rules (`eslint-plugin/prefer-object-rule`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/prefer-output-null.md
+++ b/docs/rules/prefer-output-null.md
@@ -1,6 +1,6 @@
 # Disallow invalid RuleTester test cases where the `output` matches the `code` (`eslint-plugin/prefer-output-null`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/require-meta-fixable.md
+++ b/docs/rules/require-meta-fixable.md
@@ -1,6 +1,6 @@
 # Require rules to implement a `meta.fixable` property (`eslint-plugin/require-meta-fixable`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/docs/rules/require-meta-has-suggestions.md
+++ b/docs/rules/require-meta-has-suggestions.md
@@ -1,6 +1,6 @@
 # Require suggestable rules to implement a `meta.hasSuggestions` property (`eslint-plugin/require-meta-has-suggestions`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/require-meta-schema.md
+++ b/docs/rules/require-meta-schema.md
@@ -1,6 +1,6 @@
 # Require rules to implement a `meta.schema` property (`eslint-plugin/require-meta-schema`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 

--- a/docs/rules/require-meta-type.md
+++ b/docs/rules/require-meta-type.md
@@ -1,6 +1,6 @@
 # Require rules to implement a `meta.type` property (`eslint-plugin/require-meta-type`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
+💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets).
 
 <!-- end auto-generated rule header -->
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:package-json": "npmPkgJsonLint .",
     "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive",
-    "update:eslint-docs": "eslint-doc-generator --rule-doc-section-include \"Rule Detail\" --ignore-config all --ignore-config rules --ignore-config rules-recommended --ignore-config tests --ignore-config tests-recommended"
+    "update:eslint-docs": "eslint-doc-generator"
   },
   "files": [
     "lib/"
@@ -56,7 +56,7 @@
     "eslint": "^8.23.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^0.19.0",
+    "eslint-doc-generator": "^0.28.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "file:./",
     "eslint-plugin-markdown": "^3.0.0",


### PR DESCRIPTION
* Move the options to a config file `.eslint-doc-generatorrc.js`
* Add the URL to the configs documentation to link to whenever mentioning configs

Latest release of [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator): https://github.com/bmish/eslint-doc-generator/releases/tag/v0.28.0