### PR TITLE
chore: add `eslint-remote-tester`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules/
 npm-debug.log
 yarn.lock
 .eslintcache
+
+# eslint-remote-tester
+.cache-eslint-remote-tester
+eslint-remote-tester-results

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ yarn.lock
 .eslintcache
 
 # eslint-remote-tester
-.cache-eslint-remote-tester
 eslint-remote-tester-results

--- a/eslint-remote-tester.config.js
+++ b/eslint-remote-tester.config.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { getPathIgnorePattern } = require('eslint-remote-tester-repositories');
-
 /** @type {import('eslint-remote-tester').Config} */
 module.exports = {
   /** Repositories to scan */
@@ -37,11 +35,8 @@ module.exports = {
     'typescript-eslint/typescript-eslint',
   ],
 
-  /** Optional pattern used to exclude paths */
-  pathIgnorePattern: getPathIgnorePattern(),
-
   /** Extensions of files under scanning */
-  extensions: ['js', 'ts'],
+  extensions: ['js', 'mjs', 'cjs', 'ts', 'mts', 'cts'],
 
   /** Optional boolean flag used to enable caching of cloned repositories. For CIs it's ideal to disable caching. Defaults to true. */
   cache: false,
@@ -49,5 +44,12 @@ module.exports = {
   /** ESLint configuration */
   eslintrc: {
     extends: ['plugin:eslint-plugin/all'],
+
+    overrides: [
+      {
+        files: ['*.ts', '*.mts', '*.cts'],
+        parser: '@typescript-eslint/parser',
+      },
+    ],
   },
 };

--- a/eslint-remote-tester.config.js
+++ b/eslint-remote-tester.config.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { getPathIgnorePattern } = require('eslint-remote-tester-repositories');
+
+module.exports = {
+  /** Repositories to scan */
+  repositories: [
+    // A few dozen top ESLint plugins.
+    'Intellicode/eslint-plugin-react-native',
+    'JoshuaKGoldberg/eslint-plugin-expect-type',
+    'SonarSource/eslint-plugin-sonarjs',
+    'avajs/eslint-plugin-ava',
+    'cypress-io/eslint-plugin-cypress',
+    'dangreenisrael/eslint-plugin-jest-formatting',
+    'ember-cli/eslint-plugin-ember',
+    'emberjs/eslint-plugin-ember-internal',
+    'eslint-community/eslint-plugin-eslint-plugin',
+    'eslint-community/eslint-plugin-n',
+    'eslint-community/eslint-plugin-promise',
+    'eslint-community/eslint-plugin-security',
+    'eslint-functional/eslint-plugin-functional',
+    'eslint/eslint',
+    'import-js/eslint-plugin-import',
+    'jest-community/eslint-plugin-jest',
+    'jest-community/eslint-plugin-jest-extended',
+    'jsx-eslint/eslint-plugin-jsx-a11y',
+    'jsx-eslint/eslint-plugin-react',
+    'lo1tuma/eslint-plugin-mocha',
+    'ota-meshi/eslint-plugin-regexp',
+    'platinumazure/eslint-plugin-qunit',
+    'sindresorhus/eslint-plugin-unicorn',
+    'square/eslint-plugin-square',
+    'storybookjs/eslint-plugin-storybook',
+    'testing-library/eslint-plugin-jest-dom',
+    'testing-library/eslint-plugin-testing-library',
+    'typescript-eslint/typescript-eslint',
+  ],
+
+  /** Optional pattern used to exclude paths */
+  pathIgnorePattern: getPathIgnorePattern(),
+
+  /** Extensions of files under scanning */
+  extensions: ['js', 'ts'],
+
+  /** Optional boolean flag used to enable caching of cloned repositories. For CIs it's ideal to disable caching. Defaults to true. */
+  cache: false,
+
+  /** ESLint configuration */
+  eslintrc: {
+    extends: ['plugin:eslint-plugin/all'],
+  },
+};

--- a/eslint-remote-tester.config.js
+++ b/eslint-remote-tester.config.js
@@ -2,6 +2,7 @@
 
 const { getPathIgnorePattern } = require('eslint-remote-tester-repositories');
 
+/** @type {import('eslint-remote-tester').Config} */
 module.exports = {
   /** Repositories to scan */
   repositories: [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unicorn": "^44.0.0",
     "eslint-remote-tester": "^3.0.0",
-    "eslint-remote-tester-repositories": "^1.0.0",
     "eslint-scope": "^7.1.1",
     "espree": "^9.4.0",
     "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:js": "eslint --cache --ignore-pattern \"**/*.md\" .",
     "lint:js-docs": "eslint --no-inline-config \"**/*.md\"",
     "lint:package-json": "npmPkgJsonLint .",
+    "lint:remote": "eslint-remote-tester",
     "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive",
     "update:eslint-docs": "eslint-doc-generator"
@@ -63,6 +64,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unicorn": "^44.0.0",
+    "eslint-remote-tester": "^3.0.0",
+    "eslint-remote-tester-repositories": "^1.0.0",
     "eslint-scope": "^7.1.1",
     "espree": "^9.4.0",
     "husky": "^8.0.1",


### PR DESCRIPTION
This runs all our rules on top ESLint plugin repos to ensure that they don't crash. It's like smoke testing. 

https://github.com/AriPerkkio/eslint-remote-tester