### PR TITLE
perf: use improved comparison algorithm in `no-identical-tests` rule

### DIFF
--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -38,48 +38,28 @@ module.exports = {
     // Helpers
     // ----------------------------------------------------------------------
     /**
-     *compare two test cases despite of properties order.
-     *@returns {boolean} if eq, return true, else return false.
+     * Create a unique cache key
+     * @param {object} test
+     * @returns {string}
      */
-    function eq(testA, testB) {
-      if (testA.type !== testB.type) {
-        return false;
+    function toKey(test) {
+      if (test.type !== 'ObjectExpression') {
+        return JSON.stringify([test.type, sourceCode.getText(test)]);
       }
-
-      if (testA.type !== 'ObjectExpression') {
-        return sourceCode.getText(testA) === sourceCode.getText(testB);
-      }
-
-      const propertiesA = testA.properties;
-      const propertiesB = testB.properties;
-
-      // if properties length not eq; return false;
-      if (propertiesA.length !== propertiesB.length) {
-        return false;
-      }
-
-      const propertiesSetA = new Set();
-      propertiesA.forEach((item) => {
-        const code = sourceCode.getText(item);
-        propertiesSetA.add(code);
-      });
-
-      for (const element of propertiesB) {
-        const code = sourceCode.getText(element);
-        if (!propertiesSetA.has(code)) {
-          return false;
-        }
-      }
-      return true;
+      return JSON.stringify([
+        test.type,
+        ...test.properties.map((p) => sourceCode.getText(p)).sort(),
+      ]);
     }
 
     return {
       Program(ast) {
         utils.getTestInfo(context, ast).forEach((testRun) => {
           [testRun.valid, testRun.invalid].forEach((tests) => {
-            const cache = [];
+            const cache = new Set();
             tests.forEach((test) => {
-              if (cache.some((item) => eq(item, test))) {
+              const key = toKey(test);
+              if (cache.has(key)) {
                 context.report({
                   node: test,
                   messageId: 'identical',
@@ -96,7 +76,7 @@ module.exports = {
                   },
                 });
               } else {
-                cache.push(test);
+                cache.add(key);
               }
             });
           });


### PR DESCRIPTION
Spent some time this evening profiling eslint on the eslint repo. Noticed that this rule seems to take a little longer than I would've guessed and spend a bit of time with @jviide improving the equality algorithm used for this rule. The result is that the changes in this PR make the rule ~10x faster.

| Before | After |
|--:|--:|
| 453ms | **46ms** |