### PR TITLE
docs: split rules list into rule/test-related rules

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -2,5 +2,6 @@
 module.exports = {
   ignoreConfig: ['all', 'rules', 'rules-recommended', 'tests', 'tests-recommended'],
   ruleDocSectionInclude: ['Rule Details'],
+  ruleListSplit: 'meta.docs.category',
   urlConfigs: 'https://github.com/eslint-community/eslint-plugin-eslint-plugin#presets',
 };

--- a/README.md
+++ b/README.md
@@ -61,23 +61,21 @@ Here's an example ESLint configuration that:
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
+### Rules
+
 | Name                                                                         | Description                                                                                | 💼 | 🔧 | 💡 |
 | :--------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- | :- | :- | :- |
-| [consistent-output](docs/rules/consistent-output.md)                         | enforce consistent use of `output` assertions in rule tests                                | ✅  |    |    |
 | [fixer-return](docs/rules/fixer-return.md)                                   | require fixer functions to return a fix                                                    | ✅  |    |    |
 | [meta-property-ordering](docs/rules/meta-property-ordering.md)               | enforce the order of meta properties                                                       |    | 🔧 |    |
 | [no-deprecated-context-methods](docs/rules/no-deprecated-context-methods.md) | disallow usage of deprecated methods on rule context objects                               | ✅  | 🔧 |    |
 | [no-deprecated-report-api](docs/rules/no-deprecated-report-api.md)           | disallow the version of `context.report()` with multiple arguments                         | ✅  | 🔧 |    |
-| [no-identical-tests](docs/rules/no-identical-tests.md)                       | disallow identical tests                                                                   | ✅  | 🔧 |    |
 | [no-missing-message-ids](docs/rules/no-missing-message-ids.md)               | disallow `messageId`s that are missing from `meta.messages`                                | ✅  |    |    |
 | [no-missing-placeholders](docs/rules/no-missing-placeholders.md)             | disallow missing placeholders in rule report messages                                      | ✅  |    |    |
-| [no-only-tests](docs/rules/no-only-tests.md)                                 | disallow the test case property `only`                                                     | ✅  |    | 💡 |
 | [no-unused-message-ids](docs/rules/no-unused-message-ids.md)                 | disallow unused `messageId`s in `meta.messages`                                            | ✅  |    |    |
 | [no-unused-placeholders](docs/rules/no-unused-placeholders.md)               | disallow unused placeholders in rule report messages                                       | ✅  |    |    |
 | [no-useless-token-range](docs/rules/no-useless-token-range.md)               | disallow unnecessary calls to `sourceCode.getFirstToken()` and `sourceCode.getLastToken()` | ✅  | 🔧 |    |
 | [prefer-message-ids](docs/rules/prefer-message-ids.md)                       | require using `messageId` instead of `message` to report rule violations                   | ✅  |    |    |
 | [prefer-object-rule](docs/rules/prefer-object-rule.md)                       | disallow function-style rules                                                              | ✅  | 🔧 |    |
-| [prefer-output-null](docs/rules/prefer-output-null.md)                       | disallow invalid RuleTester test cases where the `output` matches the `code`               | ✅  | 🔧 |    |
 | [prefer-placeholders](docs/rules/prefer-placeholders.md)                     | require using placeholders for dynamic report messages                                     |    |    |    |
 | [prefer-replace-text](docs/rules/prefer-replace-text.md)                     | require using `replaceText()` instead of `replaceTextRange()`                              |    |    |    |
 | [report-message-format](docs/rules/report-message-format.md)                 | enforce a consistent format for rule report messages                                       |    |    |    |
@@ -87,8 +85,17 @@ Here's an example ESLint configuration that:
 | [require-meta-has-suggestions](docs/rules/require-meta-has-suggestions.md)   | require suggestable rules to implement a `meta.hasSuggestions` property                    | ✅  | 🔧 |    |
 | [require-meta-schema](docs/rules/require-meta-schema.md)                     | require rules to implement a `meta.schema` property                                        | ✅  |    | 💡 |
 | [require-meta-type](docs/rules/require-meta-type.md)                         | require rules to implement a `meta.type` property                                          | ✅  |    |    |
-| [test-case-property-ordering](docs/rules/test-case-property-ordering.md)     | require the properties of a test case to be placed in a consistent order                   |    | 🔧 |    |
-| [test-case-shorthand-strings](docs/rules/test-case-shorthand-strings.md)     | enforce consistent usage of shorthand strings for test cases with no options               |    | 🔧 |    |
+
+### Tests
+
+| Name                                                                     | Description                                                                  | 💼 | 🔧 | 💡 |
+| :----------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :- | :- | :- |
+| [consistent-output](docs/rules/consistent-output.md)                     | enforce consistent use of `output` assertions in rule tests                  | ✅  |    |    |
+| [no-identical-tests](docs/rules/no-identical-tests.md)                   | disallow identical tests                                                     | ✅  | 🔧 |    |
+| [no-only-tests](docs/rules/no-only-tests.md)                             | disallow the test case property `only`                                       | ✅  |    | 💡 |
+| [prefer-output-null](docs/rules/prefer-output-null.md)                   | disallow invalid RuleTester test cases where the `output` matches the `code` | ✅  | 🔧 |    |
+| [test-case-property-ordering](docs/rules/test-case-property-ordering.md) | require the properties of a test case to be placed in a consistent order     |    | 🔧 |    |
+| [test-case-shorthand-strings](docs/rules/test-case-shorthand-strings.md) | enforce consistent usage of shorthand strings for test cases with no options |    | 🔧 |    |
 
 <!-- end auto-generated rules list -->
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "^8.23.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^1.0.0",
+    "eslint-doc-generator": "^1.4.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "file:./",
     "eslint-plugin-markdown": "^3.0.0",


### PR DESCRIPTION
Split the rules list into two lists, one for rule-implementation-file rules and one for test-file rules. This is a big win for organization that helps make it easier to find and understand the focus of each fule. It also matches how we have separate `rules` / `tests` configs available.

I originally added [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) in #312. It has a [`--rule-list-split` option](https://github.com/bmish/eslint-doc-generator#configuration-options) that we can use to conveniently split the rules list based on our existing `meta.docs.category` rule property.