### PR TITLE
Ignore `SpreadExpression`s in `no-only-tests` and `prefer-output-null`

### DIFF
--- a/lib/rules/no-only-tests.js
+++ b/lib/rules/no-only-tests.js
@@ -36,6 +36,7 @@ module.exports = {
 
               const onlyProperty = test.properties.find(
                 (property) =>
+                  property.type === 'Property' &&
                   property.key.type === 'Identifier' &&
                   property.key.name === 'only' &&
                   property.value.type === 'Literal' &&

--- a/lib/rules/prefer-output-null.js
+++ b/lib/rules/prefer-output-null.js
@@ -48,7 +48,9 @@ module.exports = {
              */
             function getTestInfo(key) {
               if (test.type === 'ObjectExpression') {
-                return test.properties.find((item) => item.key.name === key);
+                return test.properties.find(
+                  (item) => item.type === 'Property' && item.key.name === key
+                );
               }
               return null;
             }

--- a/tests/lib/rules/no-only-tests.js
+++ b/tests/lib/rules/no-only-tests.js
@@ -23,7 +23,8 @@ ruleTester.run('no-only-tests', rule, {
           'foo',
           { code: 'foo', foo: true },
           RuleTester.somethingElse(),
-          notRuleTester.only()
+          notRuleTester.only(),
+          { ...otherOptions },
         ],
         invalid: [
           { code: 'bar', foo: true },

--- a/tests/lib/rules/prefer-output-null.js
+++ b/tests/lib/rules/prefer-output-null.js
@@ -25,6 +25,7 @@ ruleTester.run('prefer-output-null', rule, {
       new RuleTester().run('foo', bar, {
         valid: [],
         invalid: [
+          { ...otherOptions },
           {code: 'foo', output: 'bar', errors: ['bar']},
         ]
       });


### PR DESCRIPTION
Without this change, the rules error at spread expressions in rule tests. I've added test cases to reproduce the issue.