### PR TITLE
fix: Ignore function calls in `report-message-format`

### DIFF
--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -112,7 +112,9 @@ module.exports = {
 
           if (suggest && suggest.type === 'ArrayExpression') {
             suggest.elements
-              .flatMap((obj) => obj.properties)
+              .flatMap(
+                (obj) => obj.type === 'ObjectExpression' ? obj.properties : []
+              )
               .filter(
                 (prop) =>
                   prop.type === 'Property' &&

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -108,6 +108,17 @@ ruleTester.run('report-message-format', rule, {
       options: ['^foo$'],
     },
     {
+      // Suggestion function
+      code: `
+        module.exports = {
+          create(context) {
+            context.report({node, suggest: [getSuggestion(node)]});
+          }
+        };
+      `,
+      options: ['^foo$'],
+    },
+    {
       // Suggestion message
       code: `
         module.exports = {


### PR DESCRIPTION
Without this change, the rule errors. I've added a test case to reproduce the issue.