### PR TITLE
fix: use latest ECMAScript version in tests

### DIFF
--- a/tests/lib/rules/no-only-tests.js
+++ b/tests/lib/rules/no-only-tests.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 'latest' } });
 ruleTester.run('no-only-tests', rule, {
   valid: [
     // No test cases with `only`

--- a/tests/lib/rules/prefer-output-null.js
+++ b/tests/lib/rules/prefer-output-null.js
@@ -18,7 +18,7 @@ const ERROR = { messageId: 'useOutputNull', type: 'Property' };
 // Tests
 // ------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 'latest' } });
 ruleTester.run('prefer-output-null', rule, {
   valid: [
     `


### PR DESCRIPTION
fix the ci failing in main: https://github.com/eslint-community/eslint-plugin-eslint-plugin/actions/runs/5594530270/jobs/10229475712