### PR TITLE
docs: auto-generate some rule option lists with eslint-doc-generator

### DIFF
--- a/docs/rules/require-meta-docs-description.md
+++ b/docs/rules/require-meta-docs-description.md
@@ -49,9 +49,13 @@ module.exports = {
 
 ## Options
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-* `String` — `pattern` — A regular expression that the description must match. Use `'.+'` to allow anything. Defaults to `^(enforce|require|disallow)`.
+| Name      | Description                                                                         | Type   | Default                         |
+| :-------- | :---------------------------------------------------------------------------------- | :----- | :------------------------------ |
+| `pattern` | A regular expression that the description must match. Use `'.+'` to allow anything. | String | `^(enforce\|require\|disallow)` |
+
+<!-- end auto-generated rule options list -->
 
 ## Further Reading
 

--- a/docs/rules/require-meta-docs-url.md
+++ b/docs/rules/require-meta-docs-url.md
@@ -77,7 +77,13 @@ module.exports = {
 
 ## Options
 
-This rule has an option.
+<!-- begin auto-generated rule options list -->
+
+| Name      | Description                                                                                                                                                                    | Type   |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----- |
+| `pattern` | A pattern to enforce rule's document URL. It replaces `{{name}}` placeholder by each rule name. The rule name is the basename of each rule file. Omitting this allows any URL. | String |
+
+<!-- end auto-generated rule options list -->
 
 ```json
 {
@@ -86,8 +92,6 @@ This rule has an option.
   }]
 }
 ```
-
-- `pattern` (`string`) ... A pattern to enforce rule's document URL. It replaces `{{name}}` placeholder by each rule name. The rule name is the basename of each rule file. Default is `undefined` which allows any URL.
 
 If you set the `pattern` option, this rule adds `meta.docs.url` property automatically when you execute `eslint --fix` command.
 

--- a/docs/rules/require-meta-fixable.md
+++ b/docs/rules/require-meta-fixable.md
@@ -92,9 +92,13 @@ module.exports = {
 
 ## Options
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-* `boolean` — `catchNoFixerButFixableProperty` — default `false` - Whether the rule should attempt to detect rules that do not have a fixer but enable the `meta.fixable` property. This option is off by default because it increases the chance of false positives since fixers can't always be detected when helper functions are used.
+| Name                             | Description                                                                                                                                                                                                                                                             | Type    | Default |
+| :------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `catchNoFixerButFixableProperty` | Whether the rule should attempt to detect rules that do not have a fixer but enable the `meta.fixable` property. This option is off by default because it increases the chance of false positives since fixers can't always be detected when helper functions are used. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->
 
 ## Further Reading
 

--- a/docs/rules/require-meta-schema.md
+++ b/docs/rules/require-meta-schema.md
@@ -75,9 +75,13 @@ module.exports = {
 
 ## Options
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-* `boolean` — `requireSchemaPropertyWhenOptionless` — Whether the rule should require the `meta.schema` property to be specified (with `schema: []`) for rules that have no options. Defaults to `true`.
+| Name                                  | Description                                                                                                                    | Type    | Default |
+| :------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `requireSchemaPropertyWhenOptionless` | Whether the rule should require the `meta.schema` property to be specified (with `schema: []`) for rules that have no options. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## When Not To Use It
 

--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -27,6 +27,7 @@ module.exports = {
       {
         type: 'string',
         enum: ['always', 'consistent'],
+        default: 'consistent',
       },
     ],
     messages: {

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -27,6 +27,9 @@ module.exports = {
         properties: {
           pattern: {
             type: 'string',
+            description:
+              "A regular expression that the description must match. Use `'.+'` to allow anything.",
+            default: '^(enforce|require|disallow)',
           },
         },
         additionalProperties: false,

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -31,7 +31,11 @@ module.exports = {
       {
         type: 'object',
         properties: {
-          pattern: { type: 'string' },
+          pattern: {
+            type: 'string',
+            description:
+              "A pattern to enforce rule's document URL. It replaces `{{name}}` placeholder by each rule name. The rule name is the basename of each rule file. Omitting this allows any URL.",
+          },
         },
         additionalProperties: false,
       },

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -29,6 +29,8 @@ module.exports = {
           catchNoFixerButFixableProperty: {
             type: 'boolean',
             default: false,
+            description:
+              "Whether the rule should attempt to detect rules that do not have a fixer but enable the `meta.fixable` property. This option is off by default because it increases the chance of false positives since fixers can't always be detected when helper functions are used.",
           },
         },
         additionalProperties: false,

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -25,6 +25,8 @@ module.exports = {
           requireSchemaPropertyWhenOptionless: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should require the `meta.schema` property to be specified (with `schema: []`) for rules that have no options.',
           },
         },
         additionalProperties: false,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint": "^8.23.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^1.5.1",
+    "eslint-doc-generator": "^1.6.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "file:./",
     "eslint-plugin-markdown": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint": "^8.23.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^1.4.3",
+    "eslint-doc-generator": "^1.5.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "file:./",
     "eslint-plugin-markdown": "^3.0.0",


### PR DESCRIPTION
Moves information about rule options into rule schemas so rule doc option lists can be autogenerated.

Note that I have only added these auto-generated option lists to rules with simple object-based options. Other types of options (enums/arrays/etc) aren't supported yet.

This feature shipped in:
* https://github.com/bmish/eslint-doc-generator/releases/tag/v1.5.0
* https://github.com/bmish/eslint-doc-generator/pull/480

