### PR TITLE
feat: add type comment to exported plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,7 @@ const allRules = Object.fromEntries(
     ]),
 );
 
+/** @type {import("eslint").ESLint.Plugin} */
 const plugin = {
   meta: {
     name: packageMetadata.name,


### PR DESCRIPTION
Fixes #487.

This will give a bit nicer of an IDE experience for folks working in editors such as VS Code that have built-in TypeScript support.