### PR TITLE
fix: fix `require-meta-schema-description` rule crash

### DIFF
--- a/lib/rules/require-meta-schema-description.js
+++ b/lib/rules/require-meta-schema-description.js
@@ -60,6 +60,9 @@ module.exports = {
       let hadDescription = false;
 
       for (const { key, value } of node.properties) {
+        if (!key) {
+          continue;
+        }
         const staticKey =
           key.type === 'Identifier' ? { value: key.name } : getStaticValue(key);
         if (!staticKey?.value) {

--- a/tests/lib/rules/require-meta-schema-description.js
+++ b/tests/lib/rules/require-meta-schema-description.js
@@ -167,6 +167,21 @@ module.exports = {
     schema: [
       {
         type: 'object',
+        properties: {
+          ...schemaProperties,
+        },
+      }
+    ],
+  },
+  create() {}
+}
+  `,
+`
+module.exports = {
+  meta: {
+    schema: [
+      {
+        type: 'object',
         properties: Object.fromEntries(
           Object.keys(DEFAULT_OPTIONS).map((code) => [
             code,
@@ -179,7 +194,7 @@ module.exports = {
   },
   create() {}
 }
-  `,
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
The rule crashes when the rest operator is used in the rule's metadata.

```
Oops! Something went wrong! :(

ESLint: 9.15.0

TypeError: Error while loading rule 'eslint-plugin/require-meta-schema-description': Cannot read properties of undefined (reading 'type')
Occurred while linting /Users/azat/Developer/eslint-plugin-perfectionist/rules/sort-classes.ts
    at checkSchemaElement (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint-plugin-eslint-plugin@6.3.1_eslint@9.15.0_jiti@2.4.0_/node_modules/eslint-plugin-eslint-plugin/lib/rules/require-meta-schema-description.js:67:15)
    at checkSchemaElement (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint-plugin-eslint-plugin@6.3.1_eslint@9.15.0_jiti@2.4.0_/node_modules/eslint-plugin-eslint-plugin/lib/rules/require-meta-schema-description.js:96:19)
    at Object.create (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint-plugin-eslint-plugin@6.3.1_eslint@9.15.0_jiti@2.4.0_/node_modules/eslint-plugin-eslint-plugin/lib/rules/require-meta-schema-description.js:49:7)
    at createRuleListeners (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:944:21)
    at /Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1082:84
    at Array.forEach (<anonymous>)
    at runRules (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1013:34)
    at #flatVerifyWithoutProcessors (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1911:31)
    at Linter._verifyWithFlatConfigArrayAndWithoutProcessors (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:1993:49)
    at Linter._verifyWithFlatConfigArray (/Users/azat/Developer/eslint-plugin-perfectionist/node_modules/.pnpm/eslint@9.15.0_jiti@2.4.0/node_modules/eslint/lib/linter/linter.js:2082:21)

Oops! Something went wrong! :(

ESLint: 9.15.0
```