### PR TITLE
Remove mention of `sourceType` in the recommended config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ npm install eslint-plugin-eslint-plugin --save-dev
 
 Here's an example ESLint configuration that:
 
-- Sets `sourceType` to `script` for CJS plugins (most users) (use `module` for ESM/TypeScript)
 - Enables the `recommended` configuration
 - Enables an optional/non-recommended rule
+
+Note: you might need to set `sourceType` to `script` (most users) (use `module` for ESM/TypeScript).
 
 ### <a name='eslintrc'></a>**[.eslintrc.json](https://eslint.org/docs/latest/use/configure/configuration-files)**
 


### PR DESCRIPTION
The recommended configuration doesn't set `sourceType` to `script` anymore.

Fixes https://github.com/eslint-community/eslint-plugin-eslint-plugin/issues/514