### PR TITLE
ci: add node v24 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 24
           - 23
           - 22
           - 21
@@ -40,13 +41,13 @@ jobs:
   eslint8:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
         node-version: "lts/*"
-    - run: npm install
-    - run: npm install --save-dev eslint@8
-    - run: npm test
+      - run: npm install
+      - run: npm install --save-dev eslint@8
+      - run: npm test
 
   test-remote:
     name: eslint-remote-tester

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-        node-version: "lts/*"
+          node-version: "lts/*"
       - run: npm install
       - run: npm install --save-dev eslint@8
       - run: npm test


### PR DESCRIPTION
This change adds node v24 to the matrix for ci testing

Closes #521 