### PR TITLE
chore: update typescript deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "@eslint/js": "^9.16.0",
     "@release-it/conventional-changelog": "^9.0.3",
     "@types/eslint": "^9.6.1",
-    "@types/estree": "^1.0.5",
-    "@typescript-eslint/parser": "^7.7.0",
-    "@typescript-eslint/utils": "^7.7.0",
+    "@types/estree": "^1.0.8",
+    "@typescript-eslint/parser": "^8.34.1",
+    "@typescript-eslint/utils": "^8.34.1",
     "chai": "^4.5.0",
     "eslint": "^9.16.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
@@ -83,7 +83,7 @@
     "nyc": "^17.1.0",
     "prettier": "^3.4.1",
     "release-it": "^17.2.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.3"
   },
   "peerDependencies": {
     "eslint": ">=8.23.0"

--- a/tests/lib/rules/no-property-in-node.js
+++ b/tests/lib/rules/no-property-in-node.js
@@ -8,7 +8,9 @@ const ruleTester = new RuleTester({
   languageOptions: {
     parser: require('@typescript-eslint/parser'),
     parserOptions: {
-      project: './tsconfig.json',
+      projectService: {
+        defaultProject: 'tsconfig.json',
+      },
       tsconfigRootDir: path.join(__dirname, '../fixtures'),
     },
   },


### PR DESCRIPTION
Not external facing.

Includes a fix for:
- https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#project-service