### PR TITLE
refactor: remove context compat functions

### DIFF
--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -3,7 +3,7 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
+import { getKeyName, getTestInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -44,13 +44,13 @@ const rule = {
 
     return {
       Program(ast) {
-        utils.getTestInfo(context, ast).forEach((testRun) => {
+        getTestInfo(context, ast).forEach((testRun) => {
           const readableCases = testRun.invalid.filter(
             (testCase) => testCase.type === 'ObjectExpression',
           );
           const casesWithoutOutput = readableCases.filter(
             (testCase) =>
-              !testCase.properties.map(utils.getKeyName).includes('output'),
+              !testCase.properties.map(getKeyName).includes('output'),
           );
 
           if (

--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -3,12 +3,13 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-// ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  getContextIdentifiers,
+  isAutoFixerFunction,
+  isSuggestionFixerFunction,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -70,7 +71,6 @@ const rule = {
      * Check if a returned/yielded node is likely to be a fix or not.
      * A fix is an object created by fixer.replaceText() for example and returned by the fix function.
      * @param {ASTNode} node - node to check
-     * @param {Context} context
      * @returns {boolean}
      */
     function isFix(node) {
@@ -78,7 +78,7 @@ const rule = {
         // An empty array is not a fix.
         return false;
       }
-      const scope = utils.getScope(context);
+      const scope = context.sourceCode.getScope(node);
       const staticValue = getStaticValue(node, scope);
       if (!staticValue) {
         // If we can't find a static value, assume it's a real fix value.
@@ -96,8 +96,8 @@ const rule = {
 
     return {
       Program(ast) {
-        const sourceCode = utils.getSourceCode(context);
-        contextIdentifiers = utils.getContextIdentifiers(
+        const sourceCode = context.sourceCode;
+        contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
@@ -111,8 +111,8 @@ const rule = {
           hasYieldWithFixer: false,
           hasReturnWithFixer: false,
           shouldCheck:
-            utils.isAutoFixerFunction(node, contextIdentifiers) ||
-            utils.isSuggestionFixerFunction(node, contextIdentifiers),
+            isAutoFixerFunction(node, contextIdentifiers) ||
+            isSuggestionFixerFunction(node, contextIdentifiers),
           node,
         };
       },
@@ -146,7 +146,7 @@ const rule = {
       // Ensure the current (arrow) fixer function returned a fix.
       'ArrowFunctionExpression:exit'(node) {
         if (funcInfo.shouldCheck) {
-          const sourceCode = utils.getSourceCode(context);
+          const sourceCode = context.sourceCode;
           const loc = sourceCode.getTokenBefore(node.body).loc; // Show violation on arrow (=>).
           if (node.expression) {
             // When the return is implied (no curly braces around the body), we have to check the single body node directly.

--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -2,9 +2,7 @@
  * @fileoverview Enforces the order of meta properties
  */
 
-import * as utils from '../utils.js';
-
-const { getKeyName, getRuleInfo } = utils;
+import { getKeyName, getRuleInfo } from '../utils.js';
 
 const defaultOrder = [
   'type',
@@ -48,7 +46,7 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};

--- a/lib/rules/no-deprecated-context-methods.js
+++ b/lib/rules/no-deprecated-context-methods.js
@@ -3,7 +3,7 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
+import { getContextIdentifiers } from '../utils.js';
 
 const DEPRECATED_PASSTHROUGHS = {
   getSource: 'getText',
@@ -52,7 +52,7 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     // ----------------------------------------------------------------------
     // Public
@@ -60,7 +60,7 @@ const rule = {
 
     return {
       'Program:exit'(ast) {
-        [...utils.getContextIdentifiers(sourceCode.scopeManager, ast)]
+        [...getContextIdentifiers(sourceCode.scopeManager, ast)]
           .filter(
             (contextId) =>
               contextId.parent.type === 'MemberExpression' &&

--- a/lib/rules/no-deprecated-report-api.js
+++ b/lib/rules/no-deprecated-report-api.js
@@ -3,7 +3,7 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
+import { getContextIdentifiers, getReportInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -28,7 +28,7 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     let contextIdentifiers;
 
     // ----------------------------------------------------------------------
@@ -37,7 +37,7 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(
+        contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
@@ -58,7 +58,7 @@ const rule = {
             fix(fixer) {
               const openingParen = sourceCode.getTokenBefore(node.arguments[0]);
               const closingParen = sourceCode.getLastToken(node);
-              const reportInfo = utils.getReportInfo(node, context);
+              const reportInfo = getReportInfo(node, context);
 
               if (!reportInfo) {
                 return null;

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -3,7 +3,7 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import * as utils from '../utils.js';
+import { getTestInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -30,7 +30,7 @@ const rule = {
     // ----------------------------------------------------------------------
     // Public
     // ----------------------------------------------------------------------
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     // ----------------------------------------------------------------------
     // Helpers
@@ -52,7 +52,7 @@ const rule = {
 
     return {
       Program(ast) {
-        utils.getTestInfo(context, ast).forEach((testRun) => {
+        getTestInfo(context, ast).forEach((testRun) => {
           [testRun.valid, testRun.invalid].forEach((tests) => {
             const cache = new Set();
             tests.forEach((test) => {

--- a/lib/rules/no-meta-replaced-by.js
+++ b/lib/rules/no-meta-replaced-by.js
@@ -2,7 +2,7 @@
  * @fileoverview Disallows the usage of `meta.replacedBy` property
  */
 
-import * as utils from '../utils.js';
+import { evaluateObjectProperties, getKeyName, getRuleInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -25,8 +25,8 @@ const rule = {
     },
   },
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
 
     if (!ruleInfo) {
       return {};
@@ -40,12 +40,10 @@ const rule = {
           return;
         }
 
-        const replacedByNode = utils
-          .evaluateObjectProperties(metaNode, sourceCode.scopeManager)
-          .find(
-            (p) =>
-              p.type === 'Property' && utils.getKeyName(p) === 'replacedBy',
-          );
+        const replacedByNode = evaluateObjectProperties(
+          metaNode,
+          sourceCode.scopeManager,
+        ).find((p) => p.type === 'Property' && getKeyName(p) === 'replacedBy');
 
         if (!replacedByNode) {
           return;

--- a/lib/rules/no-meta-schema-default.js
+++ b/lib/rules/no-meta-schema-default.js
@@ -1,5 +1,10 @@
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import {
+  getMetaSchemaNode,
+  getMetaSchemaNodeProperty,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -23,22 +28,19 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
-    const schemaNode = utils.getMetaSchemaNode(ruleInfo.meta, scopeManager);
+    const schemaNode = getMetaSchemaNode(ruleInfo.meta, scopeManager);
     if (!schemaNode) {
       return {};
     }
 
-    const schemaProperty = utils.getMetaSchemaNodeProperty(
-      schemaNode,
-      scopeManager,
-    );
+    const schemaProperty = getMetaSchemaNodeProperty(schemaNode, scopeManager);
 
     if (schemaProperty?.type === 'ObjectExpression') {
       checkSchemaElement(schemaProperty, true);

--- a/lib/rules/no-missing-message-ids.js
+++ b/lib/rules/no-missing-message-ids.js
@@ -1,4 +1,12 @@
-import * as utils from '../utils.js';
+import {
+  collectReportViolationAndSuggestionData,
+  findPossibleVariableValues,
+  getContextIdentifiers,
+  getMessagesNode,
+  getMessageIdNodeById,
+  getReportInfo,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -24,14 +32,14 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
-    const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
+    const messagesNode = getMessagesNode(ruleInfo, scopeManager);
 
     let contextIdentifiers;
 
@@ -42,11 +50,11 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
 
       CallExpression(node) {
-        const scope = utils.getScope(context);
+        const scope = sourceCode.getScope(node);
         // Check for messageId properties used in known calls to context.report();
         if (
           node.callee.type === 'MemberExpression' &&
@@ -54,20 +62,20 @@ const rule = {
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;
           }
 
           const reportMessagesAndDataArray =
-            utils.collectReportViolationAndSuggestionData(reportInfo);
+            collectReportViolationAndSuggestionData(reportInfo);
           for (const { messageId } of reportMessagesAndDataArray.filter(
             (obj) => obj.messageId,
           )) {
             const values =
               messageId.type === 'Literal'
                 ? [messageId]
-                : utils.findPossibleVariableValues(messageId, scopeManager);
+                : findPossibleVariableValues(messageId, scopeManager);
 
             // Look for any possible string values we found for this messageId.
             values.forEach((val) => {
@@ -75,12 +83,7 @@ const rule = {
                 val.type === 'Literal' &&
                 typeof val.value === 'string' &&
                 val.value !== '' &&
-                !utils.getMessageIdNodeById(
-                  val.value,
-                  ruleInfo,
-                  scopeManager,
-                  scope,
-                )
+                !getMessageIdNodeById(val.value, ruleInfo, scopeManager, scope)
               )
                 // Couldn't find this messageId in `meta.messages`.
                 context.report({

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -2,9 +2,17 @@
  * @fileoverview Disallow missing placeholders in rule report messages
  * @author Teddy Katz
  */
-
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  collectReportViolationAndSuggestionData,
+  getKeyName,
+  getReportInfo,
+  getRuleInfo,
+  getMessagesNode,
+  getMessageIdNodeById,
+  getContextIdentifiers,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -29,37 +37,37 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
 
     let contextIdentifiers;
 
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
-    const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
+    const messagesNode = getMessagesNode(ruleInfo, scopeManager);
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
-        const scope = utils.getScope(context);
+        const scope = sourceCode.getScope(node);
         if (
           node.callee.type === 'MemberExpression' &&
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;
           }
 
           const reportMessagesAndDataArray =
-            utils.collectReportViolationAndSuggestionData(reportInfo);
+            collectReportViolationAndSuggestionData(reportInfo);
 
           if (messagesNode) {
             // Check for any potential instances where we can use the messageId to fill in the message for convenience.
@@ -70,7 +78,7 @@ const rule = {
                 obj.messageId.type === 'Literal' &&
                 typeof obj.messageId.value === 'string'
               ) {
-                const correspondingMessage = utils.getMessageIdNodeById(
+                const correspondingMessage = getMessageIdNodeById(
                   obj.messageId.value,
                   ruleInfo,
                   scopeManager,
@@ -108,9 +116,7 @@ const rule = {
               ) {
                 const matchingProperty =
                   data &&
-                  data.properties.find(
-                    (prop) => utils.getKeyName(prop) === match[1],
-                  );
+                  data.properties.find((prop) => getKeyName(prop) === match[1]);
 
                 if (!matchingProperty) {
                   context.report({

--- a/lib/rules/no-only-tests.js
+++ b/lib/rules/no-only-tests.js
@@ -1,9 +1,10 @@
-import * as utils from '../utils.js';
 import {
   isCommaToken,
   isOpeningBraceToken,
   isClosingBraceToken,
 } from '@eslint-community/eslint-utils';
+
+import { getTestInfo } from '../utils.js';
 
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
@@ -27,7 +28,7 @@ const rule = {
   create(context) {
     return {
       Program(ast) {
-        for (const testRun of utils.getTestInfo(context, ast)) {
+        for (const testRun of getTestInfo(context, ast)) {
           for (const test of [...testRun.valid, ...testRun.invalid]) {
             if (test.type === 'ObjectExpression') {
               // Test case object: { code: 'const x = 123;', ... }
@@ -49,7 +50,7 @@ const rule = {
                     {
                       messageId: 'removeOnly',
                       *fix(fixer) {
-                        const sourceCode = utils.getSourceCode(context);
+                        const sourceCode = context.sourceCode;
 
                         const tokenBefore =
                           sourceCode.getTokenBefore(onlyProperty);

--- a/lib/rules/no-property-in-node.js
+++ b/lib/rules/no-property-in-node.js
@@ -1,5 +1,3 @@
-import * as utils from '../utils.js';
-
 const defaultTypedNodeSourceFileTesters = [
   /@types[/\\]estree[/\\]index\.d\.ts/,
   /@typescript-eslint[/\\]types[/\\]dist[/\\]generated[/\\]ast-spec\.d\.ts/,
@@ -88,7 +86,7 @@ const rule = {
       'BinaryExpression[operator=in]'(node) {
         // TODO: Switch this to ESLintUtils.getParserServices with typescript-eslint@>=6
         // https://github.com/eslint-community/eslint-plugin-eslint-plugin/issues/269
-        const services = utils.getparserServices(context);
+        const services = context.sourceCode.parserServices;
         if (!services.program) {
           throw new Error(
             'You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.',

--- a/lib/rules/no-unused-message-ids.js
+++ b/lib/rules/no-unused-message-ids.js
@@ -1,4 +1,13 @@
-import * as utils from '../utils.js';
+import {
+  collectReportViolationAndSuggestionData,
+  findPossibleVariableValues,
+  getContextIdentifiers,
+  getKeyName,
+  getMessageIdNodes,
+  getReportInfo,
+  getRuleInfo,
+  isVariableFromParameter,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -22,9 +31,9 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -34,7 +43,7 @@ const rule = {
     let hasSeenUnknownMessageId = false;
     let hasSeenViolationReport = false;
 
-    const messageIdNodes = utils.getMessageIdNodes(ruleInfo, scopeManager);
+    const messageIdNodes = getMessageIdNodes(ruleInfo, scopeManager);
     if (!messageIdNodes) {
       // If we can't find `meta.messages`, disable the rule.
       return {};
@@ -42,10 +51,10 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
 
-      'Program:exit'() {
+      'Program:exit'(ast) {
         if (hasSeenUnknownMessageId || !hasSeenViolationReport) {
           /*
           Bail out when the rule is likely to have false positives.
@@ -55,10 +64,10 @@ const rule = {
           return;
         }
 
-        const scope = utils.getScope(context);
+        const scope = sourceCode.getScope(ast);
 
         const messageIdNodesUnused = messageIdNodes.filter(
-          (node) => !messageIdsUsed.has(utils.getKeyName(node, scope)),
+          (node) => !messageIdsUsed.has(getKeyName(node, scope)),
         );
 
         // Report any messageIds that were never used.
@@ -67,7 +76,7 @@ const rule = {
             node: messageIdNode,
             messageId: 'unusedMessage',
             data: {
-              messageId: utils.getKeyName(messageIdNode, scope),
+              messageId: getKeyName(messageIdNode, scope),
             },
           });
         }
@@ -81,7 +90,7 @@ const rule = {
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;
           }
@@ -89,14 +98,14 @@ const rule = {
           hasSeenViolationReport = true;
 
           const reportMessagesAndDataArray =
-            utils.collectReportViolationAndSuggestionData(reportInfo);
+            collectReportViolationAndSuggestionData(reportInfo);
           for (const { messageId } of reportMessagesAndDataArray.filter(
             (obj) => obj.messageId,
           )) {
             const values =
               messageId.type === 'Literal'
                 ? [messageId]
-                : utils.findPossibleVariableValues(messageId, scopeManager);
+                : findPossibleVariableValues(messageId, scopeManager);
             if (
               values.length === 0 ||
               values.some((val) => val.type !== 'Literal')
@@ -118,12 +127,12 @@ const rule = {
           const values =
             node.value.type === 'Literal'
               ? [node.value]
-              : utils.findPossibleVariableValues(node.value, scopeManager);
+              : findPossibleVariableValues(node.value, scopeManager);
 
           if (
             values.length === 0 ||
             values.some((val) => val.type !== 'Literal') ||
-            utils.isVariableFromParameter(node.value, scopeManager)
+            isVariableFromParameter(node.value, scopeManager)
           ) {
             // When a dynamic messageId is used and we can't detect its value, disable the rule to avoid false positives.
             hasSeenUnknownMessageId = true;

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -3,8 +3,17 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  collectReportViolationAndSuggestionData,
+  getContextIdentifiers,
+  getKeyName,
+  getMessageIdNodeById,
+  getMessagesNode,
+  getReportInfo,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -29,36 +38,36 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
 
     let contextIdentifiers;
 
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
-    const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
+    const messagesNode = getMessagesNode(ruleInfo, scopeManager);
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
-        const scope = utils.getScope(context);
+        const scope = sourceCode.getScope(node);
         if (
           node.callee.type === 'MemberExpression' &&
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;
           }
 
           const reportMessagesAndDataArray =
-            utils.collectReportViolationAndSuggestionData(reportInfo);
+            collectReportViolationAndSuggestionData(reportInfo);
 
           if (messagesNode) {
             // Check for any potential instances where we can use the messageId to fill in the message for convenience.
@@ -69,7 +78,7 @@ const rule = {
                 obj.messageId.type === 'Literal' &&
                 typeof obj.messageId.value === 'string'
               ) {
-                const correspondingMessage = utils.getMessageIdNodeById(
+                const correspondingMessage = getMessageIdNodeById(
                   obj.messageId.value,
                   ruleInfo,
                   scopeManager,
@@ -107,7 +116,7 @@ const rule = {
               );
 
               data.properties.forEach((prop) => {
-                const key = utils.getKeyName(prop);
+                const key = getKeyName(prop);
                 if (!placeholdersInMessage.has(key)) {
                   context.report({
                     node: prop,

--- a/lib/rules/no-useless-token-range.js
+++ b/lib/rules/no-useless-token-range.js
@@ -3,7 +3,7 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
+import { getKeyName, getSourceCodeIdentifiers } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -28,7 +28,7 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     // ----------------------------------------------------------------------
     // Helpers
@@ -50,7 +50,7 @@ const rule = {
       return (
         arg.properties.length >= 2 ||
         (arg.properties.length === 1 &&
-          (utils.getKeyName(arg.properties[0]) !== 'includeComments' ||
+          (getKeyName(arg.properties[0]) !== 'includeComments' ||
             arg.properties[0].value.type !== 'Literal'))
       );
     }
@@ -120,7 +120,7 @@ const rule = {
 
     return {
       'Program:exit'(ast) {
-        [...utils.getSourceCodeIdentifiers(sourceCode.scopeManager, ast)]
+        [...getSourceCodeIdentifiers(sourceCode.scopeManager, ast)]
           .filter(
             (identifier) =>
               identifier.parent.type === 'MemberExpression' &&

--- a/lib/rules/prefer-message-ids.js
+++ b/lib/rules/prefer-message-ids.js
@@ -1,5 +1,12 @@
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  collectReportViolationAndSuggestionData,
+  getContextIdentifiers,
+  getKeyName,
+  getReportInfo,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -27,8 +34,8 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -41,8 +48,8 @@ const rule = {
 
     return {
       Program(ast) {
-        const scope = utils.getScope(context);
-        contextIdentifiers = utils.getContextIdentifiers(
+        const scope = sourceCode.getScope(ast);
+        contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
@@ -52,7 +59,7 @@ const rule = {
           metaNode &&
           metaNode.properties &&
           metaNode.properties.find(
-            (p) => p.type === 'Property' && utils.getKeyName(p) === 'messages',
+            (p) => p.type === 'Property' && getKeyName(p) === 'messages',
           );
 
         if (!messagesNode) {
@@ -86,14 +93,15 @@ const rule = {
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;
           }
 
-          const reportMessagesAndDataArray = utils
-            .collectReportViolationAndSuggestionData(reportInfo)
-            .filter((obj) => obj.message);
+          const reportMessagesAndDataArray =
+            collectReportViolationAndSuggestionData(reportInfo).filter(
+              (obj) => obj.message,
+            );
           for (const { message } of reportMessagesAndDataArray) {
             context.report({
               node: message.parent,

--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -2,7 +2,7 @@
  * @author Brad Zacher <https://github.com/bradzacher>
  */
 
-import * as utils from '../utils.js';
+import { getRuleInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -30,8 +30,8 @@ const rule = {
     // Public
     // ----------------------------------------------------------------------
 
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }

--- a/lib/rules/prefer-output-null.js
+++ b/lib/rules/prefer-output-null.js
@@ -3,7 +3,7 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import * as utils from '../utils.js';
+import { getTestInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -33,18 +33,18 @@ const rule = {
     // Public
     // ----------------------------------------------------------------------
 
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     return {
       Program(ast) {
-        utils.getTestInfo(context, ast).forEach((testRun) => {
+        getTestInfo(context, ast).forEach((testRun) => {
           testRun.invalid.forEach((test) => {
             /**
              * Get a test case's giving keyname node.
              * @param {string} the keyname to find.
              * @returns {Node} found node; if not found, return null;
              */
-            function getTestInfo(key) {
+            function getTestInfoProperty(key) {
               if (test.type === 'ObjectExpression') {
                 return test.properties.find(
                   (item) => item.type === 'Property' && item.key.name === key,
@@ -53,8 +53,8 @@ const rule = {
               return null;
             }
 
-            const code = getTestInfo('code');
-            const output = getTestInfo('output');
+            const code = getTestInfoProperty('code');
+            const output = getTestInfoProperty('output');
 
             if (
               output &&

--- a/lib/rules/prefer-placeholders.js
+++ b/lib/rules/prefer-placeholders.js
@@ -3,8 +3,13 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
 import { findVariable } from '@eslint-community/eslint-utils';
+
+import {
+  collectReportViolationAndSuggestionData,
+  getContextIdentifiers,
+  getReportInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -31,7 +36,7 @@ const rule = {
   create(context) {
     let contextIdentifiers;
 
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
 
     // ----------------------------------------------------------------------
@@ -40,7 +45,7 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
         if (
@@ -49,15 +54,16 @@ const rule = {
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
 
           if (!reportInfo) {
             return;
           }
 
-          const reportMessagesAndDataArray = utils
-            .collectReportViolationAndSuggestionData(reportInfo)
-            .filter((obj) => obj.message);
+          const reportMessagesAndDataArray =
+            collectReportViolationAndSuggestionData(reportInfo).filter(
+              (obj) => obj.message,
+            );
           for (let { message: messageNode } of reportMessagesAndDataArray) {
             if (messageNode.type === 'Identifier') {
               // See if we can find the variable declaration.

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -3,7 +3,11 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import * as utils from '../utils.js';
+import {
+  getContextIdentifiers,
+  isAutoFixerFunction,
+  isSuggestionFixerFunction,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -28,7 +32,7 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     let funcInfo = {
       upper: null,
       codePath: null,
@@ -39,7 +43,7 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(
+        contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
@@ -51,8 +55,8 @@ const rule = {
           upper: funcInfo,
           codePath,
           shouldCheck:
-            utils.isAutoFixerFunction(node, contextIdentifiers) ||
-            utils.isSuggestionFixerFunction(node, contextIdentifiers),
+            isAutoFixerFunction(node, contextIdentifiers) ||
+            isSuggestionFixerFunction(node, contextIdentifiers),
           node,
         };
       },

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -4,7 +4,13 @@
  */
 
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import {
+  getContextIdentifiers,
+  getKeyName,
+  getReportInfo,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -61,8 +67,8 @@ const rule = {
       }
     }
 
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -73,8 +79,8 @@ const rule = {
 
     return {
       Program(ast) {
-        const scope = utils.getScope(context);
-        contextIdentifiers = utils.getContextIdentifiers(
+        const scope = sourceCode.getScope(ast);
+        contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
@@ -85,7 +91,7 @@ const rule = {
           ruleInfo.meta.type === 'ObjectExpression' &&
           ruleInfo.meta.properties.find(
             (prop) =>
-              prop.type === 'Property' && utils.getKeyName(prop) === 'messages',
+              prop.type === 'Property' && getKeyName(prop) === 'messages',
           );
 
         if (
@@ -101,14 +107,14 @@ const rule = {
           .forEach((it) => processMessageNode(it, scope));
       },
       CallExpression(node) {
-        const scope = utils.getScope(context);
+        const scope = sourceCode.getScope(node);
         if (
           node.callee.type === 'MemberExpression' &&
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node, context);
+          const reportInfo = getReportInfo(node, context);
           const message = reportInfo && reportInfo.message;
           const suggest = reportInfo && reportInfo.suggest;
 

--- a/lib/rules/require-meta-default-options.js
+++ b/lib/rules/require-meta-default-options.js
@@ -1,4 +1,10 @@
-import * as utils from '../utils.js';
+import {
+  evaluateObjectProperties,
+  getKeyName,
+  getMetaSchemaNode,
+  getMetaSchemaNodeProperty,
+  getRuleInfo,
+} from '../utils.js';
 
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
@@ -24,30 +30,25 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
     const metaNode = ruleInfo.meta;
 
-    const schemaNode = utils.getMetaSchemaNode(metaNode, scopeManager);
-    const schemaProperty = utils.getMetaSchemaNodeProperty(
-      schemaNode,
-      scopeManager,
-    );
+    const schemaNode = getMetaSchemaNode(metaNode, scopeManager);
+    const schemaProperty = getMetaSchemaNodeProperty(schemaNode, scopeManager);
     if (!schemaProperty) {
       return {};
     }
 
-    const metaDefaultOptions = utils
-      .evaluateObjectProperties(metaNode, scopeManager)
-      .find(
-        (p) =>
-          p.type === 'Property' && utils.getKeyName(p) === 'defaultOptions',
-      );
+    const metaDefaultOptions = evaluateObjectProperties(
+      metaNode,
+      scopeManager,
+    ).find((p) => p.type === 'Property' && getKeyName(p) === 'defaultOptions');
 
     if (
       schemaProperty.type === 'ArrayExpression' &&

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -1,5 +1,6 @@
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import { getMetaDocsProperty, getRuleInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -44,22 +45,22 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
     return {
-      Program() {
-        const scope = utils.getScope(context);
+      Program(ast) {
+        const scope = sourceCode.getScope(ast);
         const { scopeManager } = sourceCode;
 
         const {
           docsNode,
           metaNode,
           metaPropertyNode: descriptionNode,
-        } = utils.getMetaDocsProperty('description', ruleInfo, scopeManager);
+        } = getMetaDocsProperty('description', ruleInfo, scopeManager);
 
         if (!descriptionNode) {
           context.report({

--- a/lib/rules/require-meta-docs-recommended.js
+++ b/lib/rules/require-meta-docs-recommended.js
@@ -1,5 +1,10 @@
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import {
+  getMetaDocsProperty,
+  getRuleInfo,
+  isUndefinedIdentifier,
+} from '../utils.js';
 
 /**
  * @param {import('eslint').Rule.RuleFixer} fixer
@@ -55,8 +60,8 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -66,7 +71,7 @@ const rule = {
       docsNode,
       metaNode,
       metaPropertyNode: descriptionNode,
-    } = utils.getMetaDocsProperty('recommended', ruleInfo, scopeManager);
+    } = getMetaDocsProperty('recommended', ruleInfo, scopeManager);
 
     if (!descriptionNode) {
       const suggestions =
@@ -97,7 +102,7 @@ const rule = {
       return {};
     }
 
-    const staticValue = utils.isUndefinedIdentifier(descriptionNode.value)
+    const staticValue = isUndefinedIdentifier(descriptionNode.value)
       ? { value: undefined }
       : getStaticValue(descriptionNode.value);
 

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -2,13 +2,15 @@
  * @author Toru Nagashima <https://github.com/mysticatea>
  */
 
-// -----------------------------------------------------------------------------
-// Requirements
-// -----------------------------------------------------------------------------
-
 import path from 'node:path';
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  getMetaDocsProperty,
+  getRuleInfo,
+  insertProperty,
+  isUndefinedIdentifier,
+} from '../utils.js';
 
 // -----------------------------------------------------------------------------
 // Rule Definition
@@ -53,7 +55,7 @@ const rule = {
    */
   create(context) {
     const options = context.options[0] || {};
-    const filename = utils.getFilename(context);
+    const filename = context.filename;
     const ruleName =
       filename === '<input>'
         ? undefined
@@ -75,22 +77,22 @@ const rule = {
       );
     }
 
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
     return {
-      Program() {
-        const scope = utils.getScope(context);
+      Program(ast) {
+        const scope = sourceCode.getScope(ast);
         const { scopeManager } = sourceCode;
 
         const {
           docsNode,
           metaNode,
           metaPropertyNode: urlPropNode,
-        } = utils.getMetaDocsProperty('url', ruleInfo, scopeManager);
+        } = getMetaDocsProperty('url', ruleInfo, scopeManager);
 
         const staticValue = urlPropNode
           ? getStaticValue(urlPropNode.value, scope)
@@ -132,12 +134,12 @@ const rule = {
             if (urlPropNode) {
               if (
                 urlPropNode.value.type === 'Literal' ||
-                utils.isUndefinedIdentifier(urlPropNode.value)
+                isUndefinedIdentifier(urlPropNode.value)
               ) {
                 return fixer.replaceText(urlPropNode.value, urlString);
               }
             } else if (docsNode && docsNode.value.type === 'ObjectExpression') {
-              return utils.insertProperty(
+              return insertProperty(
                 fixer,
                 docsNode.value,
                 `url: ${urlString}`,
@@ -148,7 +150,7 @@ const rule = {
               metaNode &&
               metaNode.type === 'ObjectExpression'
             ) {
-              return utils.insertProperty(
+              return insertProperty(
                 fixer,
                 metaNode,
                 `docs: {\nurl: ${urlString}\n}`,

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -4,7 +4,13 @@
  */
 
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import {
+  evaluateObjectProperties,
+  getContextIdentifiers,
+  getKeyName,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -48,9 +54,9 @@ const rule = {
     const catchNoFixerButFixableProperty =
       context.options[0] && context.options[0].catchNoFixerButFixableProperty;
 
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     let contextIdentifiers;
     let usesFixFunctions;
 
@@ -60,7 +66,7 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
         if (
@@ -70,20 +76,20 @@ const rule = {
           node.callee.property.name === 'report' &&
           (node.arguments.length > 4 ||
             (node.arguments.length === 1 &&
-              utils
-                .evaluateObjectProperties(node.arguments[0], scopeManager)
-                .some((prop) => utils.getKeyName(prop) === 'fix')))
+              evaluateObjectProperties(node.arguments[0], scopeManager).some(
+                (prop) => getKeyName(prop) === 'fix',
+              )))
         ) {
           usesFixFunctions = true;
         }
       },
-      'Program:exit'() {
-        const scope = utils.getScope(context);
+      'Program:exit'(ast) {
+        const scope = sourceCode.getScope(ast);
         const metaFixableProp =
           ruleInfo &&
-          utils
-            .evaluateObjectProperties(ruleInfo.meta, scopeManager)
-            .find((prop) => utils.getKeyName(prop) === 'fixable');
+          evaluateObjectProperties(ruleInfo.meta, scopeManager).find(
+            (prop) => getKeyName(prop) === 'fixable',
+          );
 
         if (metaFixableProp) {
           const staticValue = getStaticValue(metaFixableProp.value, scope);

--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -1,5 +1,12 @@
-import * as utils from '../utils.js';
 import { getStaticValue } from '@eslint-community/eslint-utils';
+
+import {
+  evaluateObjectProperties,
+  getContextIdentifiers,
+  getKeyName,
+  getRuleInfo,
+  isUndefinedIdentifier,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -27,9 +34,9 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -42,7 +49,7 @@ const rule = {
      * @returns {boolean} whether this property should be considered to contain suggestions
      */
     function doesPropertyContainSuggestions(node) {
-      const scope = utils.getScope(context);
+      const scope = sourceCode.getScope(node);
       const staticValue = getStaticValue(node.value, scope);
       if (
         !staticValue ||
@@ -62,7 +69,7 @@ const rule = {
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
         if (
@@ -74,9 +81,10 @@ const rule = {
             (node.arguments.length === 1 &&
               node.arguments[0].type === 'ObjectExpression'))
         ) {
-          const suggestProp = utils
-            .evaluateObjectProperties(node.arguments[0], scopeManager)
-            .find((prop) => utils.getKeyName(prop) === 'suggest');
+          const suggestProp = evaluateObjectProperties(
+            node.arguments[0],
+            scopeManager,
+          ).find((prop) => getKeyName(prop) === 'suggest');
           if (suggestProp && doesPropertyContainSuggestions(suggestProp)) {
             ruleReportsSuggestions = true;
           }
@@ -93,12 +101,13 @@ const rule = {
           ruleReportsSuggestions = true;
         }
       },
-      'Program:exit'() {
-        const scope = utils.getScope(context);
+      'Program:exit'(ast) {
+        const scope = sourceCode.getScope(ast);
         const metaNode = ruleInfo && ruleInfo.meta;
-        const hasSuggestionsProperty = utils
-          .evaluateObjectProperties(metaNode, scopeManager)
-          .find((prop) => utils.getKeyName(prop) === 'hasSuggestions');
+        const hasSuggestionsProperty = evaluateObjectProperties(
+          metaNode,
+          scopeManager,
+        ).find((prop) => getKeyName(prop) === 'hasSuggestions');
         const hasSuggestionsStaticValue =
           hasSuggestionsProperty &&
           getStaticValue(hasSuggestionsProperty.value, scope);
@@ -137,7 +146,7 @@ const rule = {
               fix(fixer) {
                 if (
                   hasSuggestionsProperty.value.type === 'Literal' ||
-                  utils.isUndefinedIdentifier(hasSuggestionsProperty.value)
+                  isUndefinedIdentifier(hasSuggestionsProperty.value)
                 ) {
                   return fixer.replaceText(
                     hasSuggestionsProperty.value,

--- a/lib/rules/require-meta-schema-description.js
+++ b/lib/rules/require-meta-schema-description.js
@@ -1,5 +1,10 @@
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import {
+  getMetaSchemaNode,
+  getMetaSchemaNodeProperty,
+  getRuleInfo,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -23,22 +28,19 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
-    const schemaNode = utils.getMetaSchemaNode(ruleInfo.meta, scopeManager);
+    const schemaNode = getMetaSchemaNode(ruleInfo.meta, scopeManager);
     if (!schemaNode) {
       return {};
     }
 
-    const schemaProperty = utils.getMetaSchemaNodeProperty(
-      schemaNode,
-      scopeManager,
-    );
+    const schemaProperty = getMetaSchemaNodeProperty(schemaNode, scopeManager);
     if (schemaProperty?.type !== 'ArrayExpression') {
       return {};
     }

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -1,4 +1,11 @@
-import * as utils from '../utils.js';
+import {
+  getContextIdentifiers,
+  getMetaSchemaNode,
+  getMetaSchemaNodeProperty,
+  getRuleInfo,
+  insertProperty,
+  isUndefinedIdentifier,
+} from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -41,9 +48,9 @@ const rule = {
   },
 
   create(context) {
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
     const { scopeManager } = sourceCode;
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
@@ -59,15 +66,12 @@ const rule = {
     let hasEmptySchema = false;
     let isUsingOptions = false;
 
-    const schemaNode = utils.getMetaSchemaNode(metaNode, scopeManager);
-    const schemaProperty = utils.getMetaSchemaNodeProperty(
-      schemaNode,
-      scopeManager,
-    );
+    const schemaNode = getMetaSchemaNode(metaNode, scopeManager);
+    const schemaProperty = getMetaSchemaNodeProperty(schemaNode, scopeManager);
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
+        contextIdentifiers = getContextIdentifiers(scopeManager, ast);
 
         if (!schemaProperty) {
           return;
@@ -85,7 +89,7 @@ const rule = {
 
         if (
           schemaProperty.type === 'Literal' ||
-          utils.isUndefinedIdentifier(schemaProperty)
+          isUndefinedIdentifier(schemaProperty)
         ) {
           context.report({ node: schemaProperty, messageId: 'wrongType' });
         }
@@ -104,7 +108,7 @@ const rule = {
                     {
                       messageId: 'addEmptySchema',
                       fix(fixer) {
-                        return utils.insertProperty(
+                        return insertProperty(
                           fixer,
                           metaNode,
                           'schema: []',

--- a/lib/rules/require-meta-type.js
+++ b/lib/rules/require-meta-type.js
@@ -4,7 +4,9 @@
  */
 
 import { getStaticValue } from '@eslint-community/eslint-utils';
-import * as utils from '../utils.js';
+
+import { evaluateObjectProperties, getKeyName, getRuleInfo } from '../utils.js';
+
 const VALID_TYPES = new Set(['problem', 'suggestion', 'layout']);
 
 // ------------------------------------------------------------------------------
@@ -36,21 +38,21 @@ const rule = {
     // Public
     // ----------------------------------------------------------------------
 
-    const sourceCode = utils.getSourceCode(context);
-    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
     if (!ruleInfo) {
       return {};
     }
 
     return {
-      Program() {
-        const scope = utils.getScope(context);
+      Program(ast) {
+        const scope = sourceCode.getScope(ast);
         const { scopeManager } = sourceCode;
 
         const metaNode = ruleInfo.meta;
-        const typeNode = utils
-          .evaluateObjectProperties(metaNode, scopeManager)
-          .find((p) => p.type === 'Property' && utils.getKeyName(p) === 'type');
+        const typeNode = evaluateObjectProperties(metaNode, scopeManager).find(
+          (p) => p.type === 'Property' && getKeyName(p) === 'type',
+        );
 
         if (!typeNode) {
           context.report({

--- a/lib/rules/test-case-property-ordering.js
+++ b/lib/rules/test-case-property-ordering.js
@@ -3,7 +3,7 @@
  * @author 薛定谔的猫<hh_2013@foxmail.com>
  */
 
-import * as utils from '../utils.js';
+import { getKeyName, getTestInfo } from '../utils.js';
 
 const defaultOrder = [
   'filename',
@@ -53,15 +53,15 @@ const rule = {
     // Public
     // ----------------------------------------------------------------------
     const order = context.options[0] || defaultOrder;
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     return {
       Program(ast) {
-        utils.getTestInfo(context, ast).forEach((testRun) => {
+        getTestInfo(context, ast).forEach((testRun) => {
           [testRun.valid, testRun.invalid].forEach((tests) => {
             tests.forEach((test) => {
               const properties = (test && test.properties) || [];
-              const keyNames = properties.map(utils.getKeyName);
+              const keyNames = properties.map(getKeyName);
 
               for (let i = 0, lastChecked; i < keyNames.length; i++) {
                 const current = order.indexOf(keyNames[i]);

--- a/lib/rules/test-case-shorthand-strings.js
+++ b/lib/rules/test-case-shorthand-strings.js
@@ -3,7 +3,7 @@
  * @author Teddy Katz
  */
 
-import * as utils from '../utils.js';
+import { getKeyName, getTestInfo } from '../utils.js';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -37,7 +37,7 @@ const rule = {
 
   create(context) {
     const shorthandOption = context.options[0] || 'as-needed';
-    const sourceCode = utils.getSourceCode(context);
+    const sourceCode = context.sourceCode;
 
     // ----------------------------------------------------------------------
     // Helpers
@@ -63,7 +63,7 @@ const rule = {
               shorthand: false,
               needsLongform: !(
                 testCase.properties.length === 1 &&
-                utils.getKeyName(testCase.properties[0]) === 'code'
+                getKeyName(testCase.properties[0]) === 'code'
               ),
             };
           }
@@ -116,8 +116,7 @@ const rule = {
 
     return {
       Program(ast) {
-        utils
-          .getTestInfo(context, ast)
+        getTestInfo(context, ast)
           .map((testRun) => testRun.valid)
           .filter(Boolean)
           .forEach(reportTestCases);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -970,24 +970,3 @@ export function isVariableFromParameter(node, scopeManager) {
 
   return variable?.defs[0]?.type === 'Parameter';
 }
-
-export function getSourceCode(context) {
-  // TODO: remove contet.getSourceCode() when dropping eslint < v9
-  return context.sourceCode || context.getSourceCode();
-}
-
-export function getScope(context) {
-  // TODO: remove contet.getScope() when dropping eslint < v9
-  const sourceCode = context.sourceCode || context.getSourceCode();
-  return sourceCode.getScope?.(sourceCode.ast) || context.getScope();
-}
-
-export function getparserServices(context) {
-  // TODO: remove context.parserServices when dropping eslint < v9
-  return (context.sourceCode || context).parserServices;
-}
-
-export function getFilename(context) {
-  // TODO: just use context.filename when dropping eslint < v9
-  return context.filename || context.getFilename();
-}


### PR DESCRIPTION
This change is in support of the larger migration to TypeScript, and a followup to the removal of support for ESLint v8.  The context compatibility functions in the `utils` module were no longer necessary.  I originally did this in the TypeScript branch, but that PR's going to be large enough.  So, I'm trying to peel off smaller independent changes I can land separately first.

I also took the opportunity to shift the rules to use named imports from `utils`.