### PR TITLE
chore: switch to TypeScript for `.eslint-doc-generatorrc.ts`

### DIFF
--- a/.eslint-doc-generatorrc.ts
+++ b/.eslint-doc-generatorrc.ts
@@ -1,7 +1,7 @@
 import prettier from 'prettier';
+import type { GenerateOptions } from 'eslint-doc-generator';
 
-/** @type {import('eslint-doc-generator').GenerateOptions} */
-const config = {
+const config: GenerateOptions = {
   ignoreConfig: [
     'all',
     'all-type-checked',


### PR DESCRIPTION
Follow-up to:
- https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/534

https://github.com/bmish/eslint-doc-generator?tab=readme-ov-file#configuration-file